### PR TITLE
issue #660 bug fixed

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -710,7 +710,11 @@ public class FormEntryActivity extends Activity implements AnimationListener,
                 if (filePath != null) {
                     new File(filePath).delete();
                 }
+                        try{
                 getContentResolver().delete(mediaUri, null, null);
+                        }catch (Exception e){
+                            Log.d(t,e.getMessage());
+                        }
                 break;
             case AUDIO_CHOOSER:
             case VIDEO_CHOOSER:


### PR DESCRIPTION
 crash when taking a video with nexus 5 bug fixed by adding try catch block to  getContentResolver().delete(mediaUri, null, null);